### PR TITLE
config: correct doc comment and add complex test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,11 @@ type Config struct {
 	Override map[string]string `hcl:"override,optional"`
 
 	// Translate is a map that translates one import source into another.
-	// For example, "gopkg.in/(.*)" => "github.com/\1" would translate
+	// If the name begins and ends with `/` (forward slash) then it will
+	// be treated like a regular expression. The destination can use
+	// \1, \2, ... to reference capture groups. Note that these may need
+	// to be escaped.
+	// For example, "/gopkg.in/(.*)/" = "github.com/\\1" would translate
 	// gopkg into github (incorrectly, but the example would work).
 	Translate map[string]string `hcl:"translate,optional"`
 }

--- a/config/testdata/complex.hcl
+++ b/config/testdata/complex.hcl
@@ -1,0 +1,16 @@
+allow = ["one",
+  "two", "three/four"
+]
+
+deny = [
+    "five",
+]
+
+override = {
+   "six" = "seven"
+}
+
+translate = {
+    "eight" = "nine"
+    "/gopkg.in/(.*)/" = "github.com/\\1"
+}

--- a/config/testdata/complex.hcl.golden
+++ b/config/testdata/complex.hcl.golden
@@ -1,0 +1,17 @@
+(*config.Config)({
+ Allow: ([]string) (len=3 cap=3) {
+  (string) (len=3) "one",
+  (string) (len=3) "two",
+  (string) (len=10) "three/four"
+ },
+ Deny: ([]string) (len=1 cap=1) {
+  (string) (len=4) "five"
+ },
+ Override: (map[string]string) (len=1) {
+  (string) (len=3) "six": (string) (len=5) "seven"
+ },
+ Translate: (map[string]string) (len=2) {
+  (string) (len=15) "/gopkg.in/(.*)/": (string) (len=13) "github.com/\\1",
+  (string) (len=5) "eight": (string) (len=4) "nine"
+ }
+})


### PR DESCRIPTION
As a user unfamiliar with HCL, it was not clear how to define
an "object". I looked at the test and couldn't find anything testing
this functionality, and I also found inconsistent comments around
the use of regular expressions in the translation.

This commit adds a complex test example and corrects the comments.