### PR TITLE
Output the license URL to the xslx output

### DIFF
--- a/license/license.go
+++ b/license/license.go
@@ -6,6 +6,7 @@ package license
 type License struct {
 	Name string // Name is a human-friendly name like "MIT License"
 	SPDX string // SPDX ID of the license, blank if unknown or unavailable
+	URL  string // URL of license
 }
 
 func (l *License) String() string {

--- a/output_xlsx.go
+++ b/output_xlsx.go
@@ -61,6 +61,7 @@ func (o *XLSXOutput) Close() error {
 	f.SetCellValue(s, "C1", "SPDX ID")
 	f.SetCellValue(s, "D1", "License")
 	f.SetCellValue(s, "E1", "Allowed")
+	f.SetCellValue(s, "F1", "URL")
 	f.SetColWidth(s, "A", "A", 40)
 	f.SetColWidth(s, "B", "B", 20)
 	f.SetColWidth(s, "C", "C", 20)
@@ -124,6 +125,10 @@ func (o *XLSXOutput) Close() error {
 				f.SetCellValue(s, fmt.Sprintf("C%d", i+2), lic.SPDX)
 			}
 			f.SetCellValue(s, fmt.Sprintf("D%d", i+2), lic.String())
+			if lic.URL != nil {
+				f.SetCellValue(s, fmt.Sprintf("F%d", i+2), *lic.URL)
+				f.SetCellHyperLink(s, fmt.Sprintf("F%d", i+2), *lic.URL, "External")
+			}
 			if o.Config != nil {
 				switch o.Config.Allowed(lic) {
 				case config.StateAllowed:


### PR DESCRIPTION
Added a column to the xslx output that contain the URL of the license file.

This is the license file as detected by GitHub, but in the specific tag of the module version.